### PR TITLE
Fix jq parse error on special chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The domain to query is `<query>.dns.hashlookup.circl.lu`. The query can be `info
 ## Info of the hashlookup database
 
 ```
-dig +short -t TXT info.dns.hashlookup.circl.lu | jq -r . | jq .
+dig +short -t TXT info.dns.hashlookup.circl.lu | jq -j . | jq .
 ```
 
 ~~~json
@@ -298,7 +298,7 @@ dig +short -t TXT info.dns.hashlookup.circl.lu | jq -r . | jq .
 ## Query of a hash
 
 ```
-dig +short -t TXT 931606baaa7a2b4ef61198406f8fc3f4.dns.hashlookup.circl.lu | jq -r . | jq .
+dig +short -t TXT 931606baaa7a2b4ef61198406f8fc3f4.dns.hashlookup.circl.lu | jq -j . | jq .
 ```
 
 ~~~json


### PR DESCRIPTION
This is a fix for the following error (example query taken from README.md):

$ dig +short -t TXT 931606baaa7a2b4ef61198406f8fc3f4.dns.hashlookup.circl.lu | jq -r . | jq .
parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 2, column 34

$ dig +short -t TXT 931606baaa7a2b4ef61198406f8fc3f4.dns.hashlookup.circl.lu | jq -j . | jq .
{
  "CRC32": "13C49389",
  "FileName": "./bin/ls",
  "FileSize": "133792",
  "MD5": "931606BAAA7A2B4EF61198406F8FC3F4",
  "OpSystemCode": "362",
  "ProductCode": "217853",
  "SHA-1": "D3A21675A8F19518D8B8F3CEF0F6A21DE1DA6CC7",
  "SHA-256": "0D06F9724AF41B13CDACEA133530B9129A48450230FEEF9632D53D5BBB837C8C",
  "SpecialCode": ""
}

"jq -j ." does not add an extra line return for split records:

$ dig +short -t TXT 931606baaa7a2b4ef61198406f8fc3f4.dns.hashlookup.circl.lu | jq -r .
{"CRC32": "13C49389", "FileName": "./bin/ls", "FileSize": "133792", "MD5": "931606BAAA7A2B4EF61198406F8FC3F4", "OpSystemCode": "362", "ProductCode": "217853", "SHA-1": "D3A21675A8F19518D8B8F3CEF0F6A21DE1DA6CC7", "SHA-256": "0D06F9724AF41B13CDACEA133530B91
29A48450230FEEF9632D53D5BBB837C8C", "SpecialCode": ""}

$ dig +short -t TXT 931606baaa7a2b4ef61198406f8fc3f4.dns.hashlookup.circl.lu | jq -j .
{"CRC32": "13C49389", "FileName": "./bin/ls", "FileSize": "133792", "MD5": "931606BAAA7A2B4EF61198406F8FC3F4", "OpSystemCode": "362", "ProductCode": "217853", "SHA-1": "D3A21675A8F19518D8B8F3CEF0F6A21DE1DA6CC7", "SHA-256": "0D06F9724AF41B13CDACEA133530B9129A48450230FEEF9632D53D5BBB837C8C", "SpecialCode": ""}%
